### PR TITLE
Fetch full git history in lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary

- Add `fetch-depth: 0` to the `actions/checkout@v4` step in `.github/workflows/golangci-lint.yml`.

## Why

The attgo `current_year` check needs `origin/master` available locally to determine which files changed in a PR. With the default shallow checkout (`fetch-depth: 1`), the ref is missing, so the check logs a warning and falls back to scanning every file:

```
attgo_current_year: warning: failed to detect default branch:
  could not detect default branch: no origin/HEAD, origin/main, or origin/master found;
  checking all files
```

Setting `fetch-depth: 0` fetches the full history so the check runs in changed-files mode as intended. Surfaced while triaging the CI failure on #7.

## Test plan

- [x] Lint job on this PR completes without the `attgo_current_year` "failed to detect default branch" warning.
- [x] Lint job still runs in roughly the same time (full clone on a small repo is negligible).